### PR TITLE
Hard code cluster.id, add volume for ZK data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ ARG KAFKA_TARBALL=https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SC
 ENV KAFKA_USER=kafka \
     KAFKA_GROUP=kafka \
     KAFKA_HOME=/opt/kafka/ \
-    KAFKA_LOGS_DIR=/var/lib/kafka/data
-
-ENV KAFKA_PORT=9092 \
+    KAFKA_LOGS_DIR=/var/lib/kafka/data \
+    KAFKA_PORT=9092 \
+    ZOOKEEPER_DATA_DIR=/var/lib/zookeeper/data \
     ZOOKEEPER_PORT=2181
 
 RUN apk add --no-cache bash curl openjdk17-jre-headless supervisor
@@ -31,6 +31,7 @@ COPY start-kafka-lite.sh ${KAFKA_HOME}
 COPY supervisord.conf /etc/supervisord.conf
 
 VOLUME ${KAFKA_LOGS_DIR}
+VOLUME ${ZOOKEEPER_DATA_DIR}
 
 EXPOSE ${KAFKA_PORT}
 EXPOSE ${ZOOKEEPER_PORT}

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -14,7 +14,7 @@ transaction.state.log.min.isr=1
 EOL
 
 cat > ./zookeeper.properties <<EOL
-dataDir=/tmp/zookeeper
+dataDir=$ZOOKEEPER_DATA_DIR
 clientPort=$ZOOKEEPER_PORT
 maxClientCnxns=0
 admin.enableServer=false

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+# Note: hard-coded cluster.id generated like so:
+# python3 -c 'import uuid; print(uuid.uuid4())' | base64 | cut -b 1-22
 cat > ./kafka.properties <<EOL
 broker.id=1
+cluster.id=NTllYjBlY2YtZWRmYy00Nj
 listeners=PLAINTEXT://:$KAFKA_PORT
 zookeeper.connect=localhost:$ZOOKEEPER_PORT
 log.dirs=$KAFKA_LOGS_DIR


### PR DESCRIPTION
AFAICT, we need to hard-code a cluster ID to avoid issues restarting kafka using a persistent docker volume to avoid errors like this:

```
kafka.common.InconsistentClusterIdException: The Cluster ID osIH4U8CS7OL_yHqvZ8gOA doesn't match stored clusterId Some(Eog_re46Qo2r4AjXCJZbng) in meta.properties. The broker is trying to join the wrong cluster. Configured zookeeper.connect may be wrong.
mono-kafka-1                   | 	at kafka.server.KafkaServer.startup(KafkaServer.scala:224)
mono-kafka-1                   | 	at kafka.Kafka$.main(Kafka.scala:109)
mono-kafka-1                   | 	at kafka.Kafka.main(Kafka.scala)
mono-kafka-1                   | [2022-10-24 15:00:50,812] INFO shutting down (kafka.server.KafkaServer)
```

Also, add a volume for ZK data, so we can make it persistent over time.