### PR TITLE
Build, runtime, and tagging improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ ARG KAFKA_TARBALL=https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SC
 ENV KAFKA_USER=kafka \
     KAFKA_GROUP=kafka \
     KAFKA_HOME=/opt/kafka/ \
-    KAFKA_LOGS_DIR=/var/lib/kafka/data \
-    KAFKA_PORT=9092 \
-    ZOOKEEPER_DATA_DIR=/var/lib/zookeeper/data \
+    KAFKA_LOGS_DIR=/var/lib/kafka/logs
+
+ENV KAFKA_PORT=9092 \
     ZOOKEEPER_PORT=2181
 
 RUN apk add --no-cache bash curl openjdk17-jre-headless supervisor
@@ -31,7 +31,6 @@ COPY start-kafka-lite.sh ${KAFKA_HOME}
 COPY supervisord.conf /etc/supervisord.conf
 
 VOLUME ${KAFKA_LOGS_DIR}
-VOLUME ${ZOOKEEPER_DATA_DIR}
 
 EXPOSE ${KAFKA_PORT}
 EXPOSE ${ZOOKEEPER_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,34 +8,35 @@ ARG KAFKA_VERSION
 ARG SCALA_VERSION
 ARG KAFKA_TARBALL=https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 
-ENV KAFKA_USER=kafka \
-    KAFKA_GROUP=kafka \
-    KAFKA_HOME=/opt/kafka/ \
-    KAFKA_LOGS_DIR=/var/lib/kafka/logs
+RUN apk add --no-cache bash curl openjdk17-jre-headless supervisor \
+    && mkdir -p /opt/kafka \
+    && curl -sSL ${KAFKA_TARBALL} | tar -zxv -C /opt/kafka --strip-components=1
 
-ENV KAFKA_PORT=9092 \
-    ZOOKEEPER_PORT=2181
+ENV PATH=/opt/kafka/bin:${PATH}
 
-RUN apk add --no-cache bash curl openjdk17-jre-headless supervisor
+# Note: Default KAFKA_CLUSTER_ID generated like so:
+# echo "00000000-0000-0000-0000-000000000000" | base64 | cut -b 1-22
+ENV KAFKA_CLUSTER_ID=MDAwMDAwMDAtMDAwMC0wMD \
+    KAFKA_DATA_DIR=/var/lib/kafka/data \
+    KAFKA_PORT=9092 \
+    ZOOKEEPER_PORT=2181 \
+    LOG_DIR=/var/log/kafka
 
-RUN addgroup ${KAFKA_GROUP} && \
-    adduser -h ${KAFKA_HOME} -D -s /bin/bash -G ${KAFKA_GROUP} ${KAFKA_USER} && \
-    mkdir -p ${KAFKA_HOME} && \
-    mkdir -p ${KAFKA_LOGS_DIR} && \
-    chown -R ${KAFKA_USER}:${KAFKA_GROUP} ${KAFKA_HOME} ${KAFKA_HOME} && \
-    chown -R ${KAFKA_USER}:${KAFKA_GROUP} ${KAFKA_LOGS_DIR}
+RUN addgroup kafka \
+    && adduser -D -s /bin/bash -G kafka kafka \
+    && mkdir -p ${KAFKA_DATA_DIR} \
+    && mkdir -p ${LOG_DIR} \
+    && chown -R kafka:kafka ${KAFKA_DATA_DIR} \
+    && chown -R kafka:kafka ${LOG_DIR}
 
-RUN curl -sSL ${KAFKA_TARBALL} | tar -zxv -C ${KAFKA_HOME} --strip-components=1
-
-COPY start-kafka-lite.sh ${KAFKA_HOME}
+WORKDIR /home/kafka
+COPY start-kafka-lite.sh .
 COPY supervisord.conf /etc/supervisord.conf
 
-VOLUME ${KAFKA_LOGS_DIR}
+VOLUME ${KAFKA_DATA_DIR}
 
 EXPOSE ${KAFKA_PORT}
 EXPOSE ${ZOOKEEPER_PORT}
 
-USER ${KAFKA_USER}
-WORKDIR ${KAFKA_HOME}
-
+USER kafka
 CMD ["./start-kafka-lite.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,17 @@ ENV PATH=/opt/kafka/bin:${PATH}
 ENV KAFKA_CLUSTER_ID=MDAwMDAwMDAtMDAwMC0wMD \
     KAFKA_DATA_DIR=/var/lib/kafka/data \
     KAFKA_PORT=9092 \
+    ZOOKEEPER_DATA_DIR=/var/lib/zookeeper/data \
     ZOOKEEPER_PORT=2181 \
     LOG_DIR=/var/log/kafka
 
 RUN addgroup kafka \
     && adduser -D -s /bin/bash -G kafka kafka \
     && mkdir -p ${KAFKA_DATA_DIR} \
+    && mkdir -p ${ZOOKEEPER_DATA_DIR} \
     && mkdir -p ${LOG_DIR} \
     && chown -R kafka:kafka ${KAFKA_DATA_DIR} \
+    && chown -R kafka:kafka ${ZOOKEEPER_DATA_DIR} \
     && chown -R kafka:kafka ${LOG_DIR}
 
 WORKDIR /home/kafka
@@ -34,6 +37,7 @@ COPY start-kafka-lite.sh .
 COPY supervisord.conf /etc/supervisord.conf
 
 VOLUME ${KAFKA_DATA_DIR}
+VOLUME ${ZOOKEEPER_DATA_DIR}
 
 EXPOSE ${KAFKA_PORT}
 EXPOSE ${ZOOKEEPER_PORT}

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 KAFKA_VERSION    ?= $(shell grep KAFKA_VERSION VERSIONS    | cut -d= -f2)
 SCALA_VERSION    ?= $(shell grep SCALA_VERSION VERSIONS    | cut -d= -f2)
 RELEASE_REVISION ?= $(shell grep RELEASE_REVISION VERSIONS | cut -d= -f2)
-DOCKER_TAG       ?= mccutchen/kafka-lite:$(KAFKA_VERSION)-scala$(SCALA_VERSION)-rev$(RELEASE_REVISION)
+
+DOCKER_REPO        ?= mccutchen/kafka-lite
+DOCKER_TAG_LATEST  := $(DOCKER_REPO):latest
+DOCKER_TAG_RELEASE := $(DOCKER_REPO):$(KAFKA_VERSION)-scala$(SCALA_VERSION)-rev$(RELEASE_REVISION)
 
 build:
 	DOCKER_BUILDKIT=1 docker build \
 		--build-arg KAFKA_VERSION=$(KAFKA_VERSION) \
 		--build-arg SCALA_VERSION=$(SCALA_VERSION) \
-		-t $(DOCKER_TAG) .
+		-t $(DOCKER_TAG_RELEASE) \
+		-t $(DOCKER_TAG_LATEST) \
+		$(shell pwd)
 .PHONY: image
 
 release:
@@ -18,5 +23,7 @@ release:
 		--build-arg SCALA_VERSION=$(SCALA_VERSION) \
 		--push \
 		--platform linux/amd64,linux/arm64 \
-		-t $(DOCKER_TAG) .
+		-t $(DOCKER_TAG_LATEST) \
+		-t $(DOCKER_TAG_RELEASE) \
+		$(shell pwd)
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-KAFKA_VERSION ?= $(shell grep KAFKA_VERSION VERSIONS | cut -d= -f2)
-SCALA_VERSION ?= $(shell grep SCALA_VERSION VERSIONS | cut -d= -f2)
-DOCKER_TAG    ?= mccutchen/kafka-lite:$(KAFKA_VERSION)-scala$(SCALA_VERSION)
+KAFKA_VERSION    ?= $(shell grep KAFKA_VERSION VERSIONS | cut -d= -f2)
+SCALA_VERSION    ?= $(shell grep SCALA_VERSION VERSIONS | cut -d= -f2)
+RELEASE_REVISION ?= $(shell git rev-parse --short HEAD)
+DOCKER_TAG       ?= mccutchen/kafka-lite:$(KAFKA_VERSION)-scala$(SCALA_VERSION)-rev$(RELEASE_REVISION)
 
 build:
 	DOCKER_BUILDKIT=1 docker build \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-KAFKA_VERSION    ?= $(shell grep KAFKA_VERSION VERSIONS | cut -d= -f2)
-SCALA_VERSION    ?= $(shell grep SCALA_VERSION VERSIONS | cut -d= -f2)
-RELEASE_REVISION ?= $(shell git rev-parse --short HEAD)
+KAFKA_VERSION    ?= $(shell grep KAFKA_VERSION VERSIONS    | cut -d= -f2)
+SCALA_VERSION    ?= $(shell grep SCALA_VERSION VERSIONS    | cut -d= -f2)
+RELEASE_REVISION ?= $(shell grep RELEASE_REVISION VERSIONS | cut -d= -f2)
 DOCKER_TAG       ?= mccutchen/kafka-lite:$(KAFKA_VERSION)-scala$(SCALA_VERSION)-rev$(RELEASE_REVISION)
 
 build:

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ services:
 
 ## Building and releasing
 
+See [VERSIONS](./VERSIONS) for build parameters.  Before releasing a new
+version, bump the `RELEASE_REVISION` number.
+
 ```sh
-# Build an image tagged with the latest git commit
+# Build an image locally
 make
 
-# Build an image tagged with latest
-make VERSION=latest
-
-# Build and push an image tagged with latest
-make release VERSION=latest
+# Build and push a "release" image, which will produce a multi-arch image
+make release
 ```
 
 ## Credits

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=3
+RELEASE_REVISION=4

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=2
+RELEASE_REVISION=3

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=4
+RELEASE_REVISION=5

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,2 +1,6 @@
+# Upstream versions to track.
 KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
+
+# Bump this revision to release a new version.
+RELEASE_REVISION=2

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -12,7 +12,8 @@ transaction.state.log.min.isr=1
 EOL
 
 cat > ./zookeeper.properties <<EOL
-dataDir=/tmp/zookeeper
+cluster.id=$KAFKA_CLUSTER_ID
+dataDir=$ZOOKEEPER_DATA_DIR
 clientPort=$ZOOKEEPER_PORT
 maxClientCnxns=0
 admin.enableServer=false

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -14,7 +14,7 @@ transaction.state.log.min.isr=1
 EOL
 
 cat > ./zookeeper.properties <<EOL
-dataDir=$ZOOKEEPER_DATA_DIR
+dataDir=/tmp/zookeeper
 clientPort=$ZOOKEEPER_PORT
 maxClientCnxns=0
 admin.enableServer=false

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
-# Note: hard-coded cluster.id generated like so:
-# python3 -c 'import uuid; print(uuid.uuid4())' | base64 | cut -b 1-22
 cat > ./kafka.properties <<EOL
 broker.id=1
-cluster.id=NTllYjBlY2YtZWRmYy00Nj
+cluster.id=$KAFKA_CLUSTER_ID
 listeners=PLAINTEXT://:$KAFKA_PORT
 zookeeper.connect=localhost:$ZOOKEEPER_PORT
-log.dirs=$KAFKA_LOGS_DIR
+log.dirs=$KAFKA_DATA_DIR
 offsets.topic.replication.factor=1
 transaction.state.log.replication.factor=1
 transaction.state.log.min.isr=1

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,7 +5,7 @@
 # services
 # =============================================================================
 [program:zookeeper]
-command=./bin/zookeeper-server-start.sh ./zookeeper.properties
+command=/opt/kafka/bin/zookeeper-server-start.sh ./zookeeper.properties
 priority=0
 autostart=true
 autorestart=false
@@ -15,7 +15,7 @@ stdout_logfile_maxbytes = 0
 stdout_logfile=/dev/stdout
 
 [program:kafka]
-command=./bin/kafka-server-start.sh ./kafka.properties
+command=/opt/kafka/bin/kafka-server-start.sh ./kafka.properties
 priority=1
 autostart=true
 autorestart=false


### PR DESCRIPTION
- Simplify and clean up the docker build (most importantly by installing kafka in a more cache-friendly way)
- Allow persisting ZK data via an external volume
- Set deterministic cluster ID to avoid issues with random cluster IDs on restarts
- Include a "release revision" in docker image tags to allow iteration on this project independent of upstream version