### PR TITLE
Stop the container when any process fails and silence logs by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ ENV KAFKA_CLUSTER_ID=MDAwMDAwMDAtMDAwMC0wMD \
     ZOOKEEPER_PORT=2181 \
     LOG_DIR=/var/log/kafka
 
+# By default, the entire container will exit if any component fails. Set this
+# to false or 0 to leave the container running for debugging purposes.
+ENV EXIT_ON_FAILURE=true
+
 RUN addgroup kafka \
     && adduser -D -s /bin/bash -G kafka kafka \
     && mkdir -p ${KAFKA_DATA_DIR} \
@@ -33,7 +37,7 @@ RUN addgroup kafka \
     && chown -R kafka:kafka ${LOG_DIR}
 
 WORKDIR /home/kafka
-COPY start-kafka-lite.sh .
+COPY start-kafka-lite.sh eventlistener.py ./
 COPY supervisord.conf /etc/supervisord.conf
 
 VOLUME ${KAFKA_DATA_DIR}

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=5
+RELEASE_REVISION=6

--- a/eventlistener.py
+++ b/eventlistener.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+"""
+A script to handle the supervisord eventlistener protocol[1], in order to
+
+ 1. provide high-level updates on component process lifecycle and
+
+ 2. kill all processes if any one fails, so the container exits noisily rather
+    than continuing to run a broken state
+
+[1] http://supervisord.org/events.html
+"""
+
+import os
+import signal
+import sys
+
+
+STOPPING = False
+
+
+def main():
+    log("starting single-node kafka cluster ...")
+
+    while True:
+        # transition from ACKNOWLEDGED to READY
+        send_msg("READY")
+
+        # parse and handle the next event
+        header = parse_event(sys.stdin.readline())
+        event = parse_event(sys.stdin.read(int(header["len"])))
+        handle_event(header, event)
+
+        # transition from READY to ACKNOWLEDGED
+        send_msg("RESULT 2")
+        send_msg("OK")
+
+
+def send_msg(msg):
+    """
+    Sends a supervisord protocol message by writing it to stdout, followed by a
+    newline.
+    """
+    line_end = "" if msg == "OK" else "\n"
+    print(msg, flush=True, end=line_end)
+
+
+def parse_event(line):
+    """
+    Parse an event header or data messaage in "key1:val1 key2:val2" format into
+    a dict.
+    """
+    return dict(x.split(":") for x in line.split())
+
+
+def handle_event(header, event):
+    global STOPPING
+    if STOPPING:
+        return
+
+    event_name = header["eventname"]
+    if event_name == "SUPERVISOR_STATE_CHANGE_STOPPING":
+        log("shutting down ...")
+        STOPPING = True
+        return
+
+    process_name = event["processname"]
+
+    # we don't care about events relating to our own process
+    if process_name == "processes":
+        return
+
+    failure_events = {
+        "PROCESS_STATE_STOPPED",
+        "PROCESS_STATE_EXITED",
+        "PROCESS_STATE_FATAL",
+    }
+
+    if event_name in failure_events:
+        error_log(f"{process_name} service failed!")
+        show_troubleshooting_logs(process_name)
+
+        if os.environ.get("EXIT_ON_FAILURE", "").lower() in ("false", "0"):
+            error_log("leaving container running for troubleshooting purposes ...")
+            return
+
+        error_log("shutting down ...")
+        error_log("(set EXIT_ON_FAILURE=false leave container running)")
+        os.kill(os.getppid(), signal.SIGQUIT)
+
+    elif event_name == "PROCESS_STATE_STARTING":
+        log(f"service {process_name} starting ...")
+
+    elif event_name == "PROCESS_STATE_RUNNING":
+        log(f"service {process_name} up and running ...")
+
+
+def show_troubleshooting_logs(process_name, limit=50):
+    # both processes log to the same file
+    log_path = "/var/log/kafka/server.log"
+
+    with open(log_path) as f:
+        lines = f.readlines()
+
+    # zookeeper starts first, so its failures tend to be at the beginning of
+    # the file. kafka failures tend to be at the end.
+    if process_name == "zookeeper":
+        lines = lines[:limit]
+    else:
+        lines = lines[-limit:]
+
+    logs = "".join(lines)
+    error_log(f"to help troubleshoot, here are {limit} lines of {log_path}:\n{logs}")
+
+
+def log(msg):
+    print(f"[kafka-lite] {msg}", file=sys.stderr)
+
+
+def error_log(msg):
+    print(f"[kafka-lite][ERROR] {msg}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,9 +10,8 @@ priority=0
 autostart=true
 autorestart=false
 redirect_stderr=true
-stderr_logfile_maxbytes = 0
 stdout_logfile_maxbytes = 0
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/null
 
 [program:kafka]
 command=/opt/kafka/bin/kafka-server-start.sh ./kafka.properties
@@ -20,15 +19,15 @@ priority=1
 autostart=true
 autorestart=false
 redirect_stderr=true
-stderr_logfile_maxbytes = 0
 stdout_logfile_maxbytes = 0
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/null
 
 # =============================================================================
 # supervisord config
 # =============================================================================
 [supervisord]
 nodaemon=true
+loglevel=warn
 
 [supervisorctl]
 serverurl=http://127.0.0.1:9001
@@ -38,3 +37,12 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [inet_http_server]
 port=127.0.0.1:9001
+
+# kill all processes if any one fails, so the container exits noisily rather
+# than continuing to run a broken state.
+# https://serverfault.com/a/1039052
+[eventlistener:processes]
+command=./eventlistener.py
+events=PROCESS_STATE,SUPERVISOR_STATE_CHANGE_STOPPING
+stderr_logfile_maxbytes = 0
+stderr_logfile=/dev/stderr


### PR DESCRIPTION
With these changes, the entire container will exit if either of the zookeeper or kafka processes exits, rather than lingering in a silently broken state.

While we're at it, we also silence the extremely verbose logs by default, and instead simply log process lifecycle events:

```
[kafka-lite] starting single-node kafka cluster ...
[kafka-lite] service zookeeper starting ...
[kafka-lite] service kafka starting ...
[kafka-lite] service zookeeper up and running ...
[kafka-lite] service kafka up and running ...
```

If a process fails and we have to shut down, we do at least try to show some helpful debugging logs (note that this does capture the reason for the error, `Failed to create data directory /no/dice`):

```
[kafka-lite] starting single-node kafka cluster ...
[kafka-lite] service zookeeper starting ...
[kafka-lite] service kafka starting ...
[kafka-lite] service zookeeper up and running ...
[kafka-lite] service kafka up and running ...
[kafka-lite][ERROR] kafka service failed!
[kafka-lite][ERROR] to help troubleshoot, here are 50 lines of /var/log/kafka/server.log:
	transaction.state.log.segment.bytes = 104857600
	transactional.id.expiration.ms = 604800000
	unclean.leader.election.enable = false
	zookeeper.clientCnxnSocket = null
	zookeeper.connect = localhost:2181
	zookeeper.connection.timeout.ms = null
	zookeeper.max.in.flight.requests = 10
	zookeeper.session.timeout.ms = 18000
	zookeeper.set.acl = false
	zookeeper.ssl.cipher.suites = null
	zookeeper.ssl.client.enable = false
	zookeeper.ssl.crl.enable = false
	zookeeper.ssl.enabled.protocols = null
	zookeeper.ssl.endpoint.identification.algorithm = HTTPS
	zookeeper.ssl.keystore.location = null
	zookeeper.ssl.keystore.password = null
	zookeeper.ssl.keystore.type = null
	zookeeper.ssl.ocsp.enable = false
	zookeeper.ssl.protocol = TLSv1.2
	zookeeper.ssl.truststore.location = null
	zookeeper.ssl.truststore.password = null
	zookeeper.ssl.truststore.type = null
 (kafka.server.KafkaConfig)
[2022-10-26 23:01:08,417] INFO [ThrottledChannelReaper-Fetch]: Starting (kafka.server.ClientQuotaManager$ThrottledChannelReaper)
[2022-10-26 23:01:08,418] INFO [ThrottledChannelReaper-Produce]: Starting (kafka.server.ClientQuotaManager$ThrottledChannelReaper)
[2022-10-26 23:01:08,419] INFO [ThrottledChannelReaper-Request]: Starting (kafka.server.ClientQuotaManager$ThrottledChannelReaper)
[2022-10-26 23:01:08,419] INFO [ThrottledChannelReaper-ControllerMutation]: Starting (kafka.server.ClientQuotaManager$ThrottledChannelReaper)
[2022-10-26 23:01:08,427] INFO Log directory /no/dice not found, creating it. (kafka.log.LogManager)
[2022-10-26 23:01:08,427] ERROR Failed to create or validate data directory /no/dice (kafka.server.LogDirFailureChannel)
java.io.IOException: Failed to create data directory /no/dice
	at kafka.log.LogManager.$anonfun$createAndValidateLogDirs$1(LogManager.scala:160)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at kafka.log.LogManager.createAndValidateLogDirs(LogManager.scala:151)
	at kafka.log.LogManager.<init>(LogManager.scala:90)
	at kafka.log.LogManager$.apply(LogManager.scala:1383)
	at kafka.server.KafkaServer.startup(KafkaServer.scala:261)
	at kafka.Kafka$.main(Kafka.scala:109)
	at kafka.Kafka.main(Kafka.scala)
[2022-10-26 23:01:08,429] ERROR Shutdown broker because none of the specified log dirs from /no/dice can be created or validated (kafka.log.LogManager)
[2022-10-26 23:01:08,800] WARN Unexpected exception (org.apache.zookeeper.server.NIOServerCnxn)
EndOfStreamException: Unable to read additional data from client, it probably closed the socket: address = /127.0.0.1:53680, session = 0x10001e0788a0000
	at org.apache.zookeeper.server.NIOServerCnxn.handleFailedRead(NIOServerCnxn.java:163)
	at org.apache.zookeeper.server.NIOServerCnxn.doIO(NIOServerCnxn.java:326)
	at org.apache.zookeeper.server.NIOServerCnxnFactory$IOWorkRequest.doWork(NIOServerCnxnFactory.java:522)
	at org.apache.zookeeper.server.WorkerService$ScheduledWorkRequest.run(WorkerService.java:154)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)

[kafka-lite][ERROR] shutting down ...
[kafka-lite][ERROR] (set EXIT_ON_FAILURE=false leave container running)
2022-10-26 23:01:09,809 WARN received SIGQUIT indicating exit request
```

The behavior can be changed by running the image with `EXIT_ON_FAILURE=false`.