### PR TITLE
Add permissions required to push to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ name: Release
 jobs:
   docker:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -54,9 +59,6 @@ jobs:
         # Here we attempt to hack a multi-line string value into a single
         # output variable following this example from GitHub's docs:
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-        #
-        # That example covers $GITHUB_ENV, I have no idea if it works with
-        # $GITHUB_OUTPUT.
         run: |
           echo 'build_args<<EOF' >> $GITHUB_OUTPUT
           grep -e KAFKA_VERSION -e SCALA_VERSION VERSIONS >> $GITHUB_OUTPUT


### PR DESCRIPTION
Following the guide here:
https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action