### PR TITLE
Add support for SASL_PLAIN authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ ENV KAFKA_CLUSTER_ID=MDAwMDAwMDAtMDAwMC0wMD \
 # By default, the entire container will exit if any component fails. Set this
 # to false or 0 to leave the container running for debugging purposes.
 ENV EXIT_ON_FAILURE=true
-#enable sasl for dev clusters
-ENV KAFKA_ENABLE_SASL=""
 
 RUN addgroup kafka \
     && adduser -D -s /bin/bash -G kafka kafka \
@@ -48,7 +46,7 @@ VOLUME ${ZOOKEEPER_DATA_DIR}
 
 EXPOSE ${KAFKA_PORT}
 EXPOSE ${ZOOKEEPER_PORT}
-EXPOsE ${KAFKA_NOAUTH_PORT}
+EXPOSE ${KAFKA_NOAUTH_PORT}
 
 USER kafka
 CMD ["./start-kafka-lite.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ENV PATH=/opt/kafka/bin:${PATH}
 # echo "00000000-0000-0000-0000-000000000000" | base64 | cut -b 1-22
 ENV KAFKA_CLUSTER_ID=MDAwMDAwMDAtMDAwMC0wMD \
     KAFKA_DATA_DIR=/var/lib/kafka/data \
-    KAFKA_PORT=9092 \
+    KAFKA_NOAUTH_PORT=9092 \
+    KAFKA_PORT=9093 \
     ZOOKEEPER_DATA_DIR=/var/lib/zookeeper/data \
     ZOOKEEPER_PORT=2181 \
     LOG_DIR=/var/log/kafka
@@ -26,6 +27,8 @@ ENV KAFKA_CLUSTER_ID=MDAwMDAwMDAtMDAwMC0wMD \
 # By default, the entire container will exit if any component fails. Set this
 # to false or 0 to leave the container running for debugging purposes.
 ENV EXIT_ON_FAILURE=true
+#enable sasl for dev clusters
+ENV KAFKA_ENABLE_SASL=""
 
 RUN addgroup kafka \
     && adduser -D -s /bin/bash -G kafka kafka \
@@ -45,6 +48,7 @@ VOLUME ${ZOOKEEPER_DATA_DIR}
 
 EXPOSE ${KAFKA_PORT}
 EXPOSE ${ZOOKEEPER_PORT}
+EXPOsE ${KAFKA_NOAUTH_PORT}
 
 USER kafka
 CMD ["./start-kafka-lite.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.16
 # Scala versions with which they are built.
 ARG KAFKA_VERSION
 ARG SCALA_VERSION
-ARG KAFKA_TARBALL=https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
+ARG KAFKA_TARBALL=https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 
 RUN apk add --no-cache bash curl openjdk17-jre-headless supervisor \
     && mkdir -p /opt/kafka \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ KAFKA_VERSION    ?= $(shell grep KAFKA_VERSION VERSIONS    | cut -d= -f2)
 SCALA_VERSION    ?= $(shell grep SCALA_VERSION VERSIONS    | cut -d= -f2)
 RELEASE_REVISION ?= $(shell grep RELEASE_REVISION VERSIONS | cut -d= -f2)
 
-DOCKER_REPO        ?= mccutchen/kafka-lite
+DOCKER_REPO        ?= rudotez/kafka-lite
 DOCKER_TAG_LATEST  := $(DOCKER_REPO):latest
 DOCKER_TAG_RELEASE := $(DOCKER_REPO):$(KAFKA_VERSION)-scala$(SCALA_VERSION)-rev$(RELEASE_REVISION)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ KAFKA_VERSION    ?= $(shell grep KAFKA_VERSION VERSIONS    | cut -d= -f2)
 SCALA_VERSION    ?= $(shell grep SCALA_VERSION VERSIONS    | cut -d= -f2)
 RELEASE_REVISION ?= $(shell grep RELEASE_REVISION VERSIONS | cut -d= -f2)
 
-DOCKER_REPO        ?= rudotez/kafka-lite
+DOCKER_REPO        ?= mccutchen/kafka-lite
 DOCKER_TAG_LATEST  := $(DOCKER_REPO):latest
 DOCKER_TAG_RELEASE := $(DOCKER_REPO):$(KAFKA_VERSION)-scala$(SCALA_VERSION)-rev$(RELEASE_REVISION)
 

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=16
+RELEASE_REVISION=18

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=19
+RELEASE_REVISION=20

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=18
+RELEASE_REVISION=19

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=13
+RELEASE_REVISION=16

--- a/VERSIONS
+++ b/VERSIONS
@@ -3,4 +3,4 @@ KAFKA_VERSION=3.3.1
 SCALA_VERSION=2.13
 
 # Bump this revision to release a new version.
-RELEASE_REVISION=8
+RELEASE_REVISION=13

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Create Kafka properties file
-echo "enable SASL and  PLAINTEXT authentication"
 cat > ./kafka.properties <<EOL
 authorizer.class.name=kafka.security.authorizer.AclAuthorizer
 broker.id=1

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -15,6 +15,7 @@ super.users=User:admin
 sasl.enabled.mechanisms=PLAIN
 security.inter.broker.protocol=SASL_PLAINTEXT
 sasl.mechanism.inter.broker.protocol=PLAIN
+allow.everyone.if.no.acl.found=true
 EOL
 
 # Create JAAS configuration file for Kafka

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -24,8 +24,9 @@ cat > ./kafka_jaas.conf <<EOL
 KafkaServer {
   org.apache.kafka.common.security.plain.PlainLoginModule required
   username="admin"
-  password="admin-secret"
-  user_admin="admin-secret";
+  password="admin"
+  user_admin="admin"
+  user_user="user";
 };
 
 EOL

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -13,8 +13,9 @@ transaction.state.log.min.isr=1
 EOL
 
 if [ "$KAFKA_ENABLE_SASL" ]; then
+echo "enable sasl"
     cat >> ./kafka.properties <<EOL
-listeners=SASL_PLAINTEXT://:$KAFKA_PORT
+listeners=SASL_PLAINTEXT://:$KAFKA_PORT,PLAINTEXT://:$KAFKA_NOAUTH_PORT
 super.users=User:admin
 sasl.enabled.mechanisms=PLAIN
 security.inter.broker.protocol=SASL_PLAINTEXT

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -10,26 +10,24 @@ log.dirs=$KAFKA_DATA_DIR
 offsets.topic.replication.factor=1
 transaction.state.log.replication.factor=1
 transaction.state.log.min.isr=1
+
+# enable SASL authenticated listener and unauthenticated listener
 listeners=SASL_PLAINTEXT://:$KAFKA_PORT,PLAINTEXT://:$KAFKA_NOAUTH_PORT
-super.users=User:admin
+
+# configure SASL authentication with "admin" and "user" users
 sasl.enabled.mechanisms=PLAIN
-security.inter.broker.protocol=SASL_PLAINTEXT
-sasl.mechanism.inter.broker.protocol=PLAIN
+listener.security.protocol.map=SASL_PLAINTEXT:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT
+listener.name.sasl_plaintext.plain.sasl.enabled.mechanisms=PLAIN
+listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+    username="admin" \
+    password="admin" \
+    user_admin="admin" \
+    user_user="user";
+super.users=User:admin
+
+# allow anonymous users full admin permissions during migration period
 allow.everyone.if.no.acl.found=true
 EOL
-
-# Create JAAS configuration file for Kafka
-cat > ./kafka_jaas.conf <<EOL
-KafkaServer {
-  org.apache.kafka.common.security.plain.PlainLoginModule required
-  username="admin"
-  password="admin"
-  user_admin="admin"
-  user_user="user";
-};
-EOL
-# Export JAAS configuration file location
-export KAFKA_OPTS="-Djava.security.auth.login.config=/home/kafka/kafka_jaas.conf"
 
 cat > ./zookeeper.properties <<EOL
 cluster.id=$KAFKA_CLUSTER_ID

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -16,7 +16,6 @@ super.users=User:admin
 sasl.enabled.mechanisms=PLAIN
 security.inter.broker.protocol=SASL_PLAINTEXT
 sasl.mechanism.inter.broker.protocol=PLAIN
-
 EOL
 
 # Create JAAS configuration file for Kafka
@@ -28,7 +27,6 @@ KafkaServer {
   user_admin="admin"
   user_user="user";
 };
-
 EOL
 # Export JAAS configuration file location
 export KAFKA_OPTS="-Djava.security.auth.login.config=/home/kafka/kafka_jaas.conf"

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Create Kafka properties file
+echo "enable SASL and  PLAINTEXT authentication"
 cat > ./kafka.properties <<EOL
 authorizer.class.name=kafka.security.authorizer.AclAuthorizer
 broker.id=1
@@ -10,11 +11,6 @@ log.dirs=$KAFKA_DATA_DIR
 offsets.topic.replication.factor=1
 transaction.state.log.replication.factor=1
 transaction.state.log.min.isr=1
-EOL
-
-if [ "$KAFKA_ENABLE_SASL" ]; then
-echo "enable sasl"
-    cat >> ./kafka.properties <<EOL
 listeners=SASL_PLAINTEXT://:$KAFKA_PORT,PLAINTEXT://:$KAFKA_NOAUTH_PORT
 super.users=User:admin
 sasl.enabled.mechanisms=PLAIN
@@ -35,12 +31,6 @@ KafkaServer {
 EOL
 # Export JAAS configuration file location
 export KAFKA_OPTS="-Djava.security.auth.login.config=/home/kafka/kafka_jaas.conf"
-    
-else
-cat >> ./kafka.properties <<EOL
-listeners=PLAINTEXT://:$KAFKA_PORT
-EOL
-fi
 
 cat > ./zookeeper.properties <<EOL
 cluster.id=$KAFKA_CLUSTER_ID

--- a/start-kafka-lite.sh
+++ b/start-kafka-lite.sh
@@ -1,17 +1,33 @@
 #!/bin/bash
 
+# Create Kafka properties file
 cat > ./kafka.properties <<EOL
 authorizer.class.name=kafka.security.authorizer.AclAuthorizer
 broker.id=1
 cluster.id=$KAFKA_CLUSTER_ID
-listeners=PLAINTEXT://:$KAFKA_PORT
+listeners=SASL_PLAINTEXT://:$KAFKA_PORT
 zookeeper.connect=localhost:$ZOOKEEPER_PORT
 log.dirs=$KAFKA_DATA_DIR
 offsets.topic.replication.factor=1
 transaction.state.log.replication.factor=1
 transaction.state.log.min.isr=1
+allow.everyone.if.no.acl.found=false
+super.users=User:admin
+sasl.enabled.mechanisms=PLAIN
+security.inter.broker.protocol=SASL_PLAINTEXT
+sasl.mechanism.inter.broker.protocol=PLAIN
 EOL
 
+# Create JAAS configuration file for Kafka
+cat > ./kafka_jaas.conf <<EOL
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};
+
+EOL
 cat > ./zookeeper.properties <<EOL
 cluster.id=$KAFKA_CLUSTER_ID
 dataDir=$ZOOKEEPER_DATA_DIR
@@ -20,4 +36,8 @@ maxClientCnxns=0
 admin.enableServer=false
 EOL
 
+# Export JAAS configuration file location
+export KAFKA_OPTS="-Djava.security.auth.login.config=/home/kafka/kafka_jaas.conf"
+
+# Start Kafka and Zookeeper using supervisord
 exec supervisord --nodaemon --configuration /etc/supervisord.conf


### PR DESCRIPTION
For https://ro-engine.atlassian.net/browse/DI-1084

In order to test against a locally spun up cluster sasl auth config settings are in place.

These are the generalised credentials based on kafka confleunt documentation, however these are only for local development.

Kafka confluent sasl auth documentation:
https://kafka.apache.org/documentation/#security_sasl_plain
https://docs.confluent.io/platform/current/kafka/authentication_sasl/authentication_sasl_plain.html

TODO:
- [ ] Before changing the rodeo image will need to regression test against existing local kafka dev use cases.